### PR TITLE
[COIN-1407] remove info message for withdraw unbonded

### DIFF
--- a/src/families/polkadot/SimpleOperationFlow/01-Started.js
+++ b/src/families/polkadot/SimpleOperationFlow/01-Started.js
@@ -105,19 +105,21 @@ export default function PolkadotSimpleOperationStarted({
                 i18nKey={`polkadot.simpleOperation.modes.${mode}.description`}
               />
             </LText>
-            <View style={styles.info}>
-              <Info size={22} color={colors.live} />
-              <LText
-                semiBold
-                style={[styles.text, styles.infoText]}
-                color="live"
-                numberOfLines={3}
-              >
-                <Trans
-                  i18nKey={`polkadot.simpleOperation.modes.${mode}.info`}
-                />
-              </LText>
-            </View>
+            {!["withdrawUnbonded"].includes(mode) && (
+              <View style={styles.info}>
+                <Info size={22} color={colors.live} />
+                <LText
+                  semiBold
+                  style={[styles.text, styles.infoText]}
+                  color="live"
+                  numberOfLines={3}
+                >
+                  <Trans
+                    i18nKey={`polkadot.simpleOperation.modes.${mode}.info`}
+                  />
+                </LText>
+              </View>
+            )}
           </View>
         </View>
         <View style={styles.footer}>

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -3236,8 +3236,7 @@
       "modes": {
         "withdrawUnbonded": {
           "title": "Withdraw unbonded",
-          "description": "After the 28-day unbonding period you can withdraw unbonded assets.",
-          "info": "You can then withdraw unbonded assets to your available balance."
+          "description": "Withdraw unbonded assets to your available balance."
         },
         "chill": {
           "title": "Clear nominations",


### PR DESCRIPTION
### Type

Minor Fix

### Context
A redundant alert is displayed below the withdraw unbonded description.

We want to remove it.

### TODO

* remove the specific check, and opt-in for a more generic solution (checking the translation exists, or that the content of the translation is not empty).

### Parts of the app affected / Test plan

Polkadot Withdraw Modal should not have the redundant alert.
